### PR TITLE
Fix `checkThrows` FFI implementation

### DIFF
--- a/src/Test/Assert.ss
+++ b/src/Test/Assert.ss
@@ -17,6 +17,6 @@
         (call/cc (lambda (k)
           (with-exception-handler
             (lambda (e) (k #t))
-            (lambda () (eq? (fn 'unit) #t))))))))
+            (lambda () (begin (fn 'unit) #f))))))))
 
   )


### PR DESCRIPTION
**Description of the change**

It would misreport functions of type `Unit -> true` as throwing even if they didn't throw. This was introduced in #2.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
